### PR TITLE
Remove Vercel Analytics integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ After each guess, the game provides color-coded feedback based on five key attri
   <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB" />
   <img src="https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black" />
   <img src="https://img.shields.io/badge/TailwindCSS-06B6D4?style=for-the-badge&logo=tailwind-css&logoColor=white" />
-  <img src="https://img.shields.io/badge/Vercel-000000?style=for-the-badge&logo=vercel&logoColor=white" />
 </p>
 
 **Backend & API Development**  

--- a/frontend/stardewdle/package-lock.json
+++ b/frontend/stardewdle/package-lock.json
@@ -12,7 +12,6 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
-        "@vercel/analytics": "^2.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.0",
@@ -62,7 +61,6 @@
     "node_modules/@babel/core": {
       "version": "7.28.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -615,7 +613,6 @@
     "node_modules/@babel/plugin-syntax-flow": {
       "version": "7.27.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1383,7 +1380,6 @@
     "node_modules/@babel/plugin-transform-react-jsx": {
       "version": "7.27.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-module-imports": "^7.27.1",
@@ -2889,7 +2885,6 @@
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3256,7 +3251,6 @@
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -3306,7 +3300,6 @@
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -3466,48 +3459,6 @@
       "version": "1.3.0",
       "license": "ISC"
     },
-    "node_modules/@vercel/analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
-      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "license": "MIT",
@@ -3657,7 +3608,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3740,7 +3690,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4510,7 +4459,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6088,7 +6036,6 @@
     "node_modules/eslint": {
       "version": "8.57.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8414,7 +8361,6 @@
     "node_modules/jest": {
       "version": "27.5.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -9198,7 +9144,6 @@
     "node_modules/jiti": {
       "version": "1.21.7",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -10330,7 +10275,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11369,7 +11313,6 @@
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11718,7 +11661,6 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11842,7 +11784,6 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11861,7 +11802,6 @@
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12349,7 +12289,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -12569,7 +12508,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13426,7 +13364,6 @@
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -13643,7 +13580,6 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13778,7 +13714,6 @@
     "node_modules/type-fest": {
       "version": "0.20.2",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14128,7 +14063,6 @@
     "node_modules/webpack": {
       "version": "5.104.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -14196,7 +14130,6 @@
     "node_modules/webpack-dev-server": {
       "version": "4.15.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -14548,7 +14481,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/frontend/stardewdle/package.json
+++ b/frontend/stardewdle/package.json
@@ -7,7 +7,6 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
-    "@vercel/analytics": "^2.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0",

--- a/frontend/stardewdle/src/index.js
+++ b/frontend/stardewdle/src/index.js
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
-import { Analytics } from "@vercel/analytics/react";
 
 import { SoundProvider } from "./context/SoundContext";
 
@@ -11,7 +10,6 @@ root.render(
   <SoundProvider>
     <React.StrictMode>
       <App />
-      <Analytics />
     </React.StrictMode>
   </SoundProvider>,
 );


### PR DESCRIPTION
Remove the @vercel/analytics dependency and its usage. This deletes the Vercel analytics badge from the README, removes the import and <Analytics /> from frontend/stardewdle/src/index.js, and updates package.json and package-lock.json to drop the package and related lock entries. Cleans up an unused tracking dependency and UI element.