### PR TITLE
Update yellow tile description for partial season match

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ After each guess, the game provides color-coded feedback based on five key attri
 
 <img src="https://img.shields.io/badge/-%23538D4E?style=for-the-badge&labelColor=538D4E" alt="Green Tile" width="10" height="18" /> **Green** indicates a **Perfect Match**: your value for the attribute is **exactly correct**. This applies to all five attributes.
 
-<img src="https://img.shields.io/badge/-%23B59F3B?style=for-the-badge&labelColor=B59F3B" alt="Yellow Tile" width="10" height="18" /> **Yellow** indicates a **Partial Season Match** and **appears exclusively for the Season attribute**. If the season you guessed is one of the crop's growing seasons, but the crop also grows in at least one other season, the tile will be yellow.
+<img src="https://img.shields.io/badge/-%23B59F3B?style=for-the-badge&labelColor=B59F3B" alt="Yellow Tile" width="10" height="18" /> **Yellow** indicates a **Partial Season Match** and **appears exclusively for the Season attribute**. If the season you guessed is one of the crop's growing seasons, but the crop also grows in at least one other season; or, if you guessed multiple seasons, and one of them is the crop's growing seasons, the tile will be yellow.
 
 <img src="https://img.shields.io/badge/-%23FF4136?style=for-the-badge&labelColor=FF4136" alt="Red Tile" width="10" height="18" /> **Red** indicates the value is **Incorrect**. For the numerical attributes (**Growth Time** and **Sell Price**), a directional arrow will accompany the red tile to help you: $\bigtriangleup$ means the correct value is higher, and $\bigtriangledown$ means the correct value is lower.
 


### PR DESCRIPTION
If you guess a crop that has more than one growing season, such as corn or sunflowers, and its not both seasons, or its two different seasons, that includes one of the seasons of the crop, then it's also yellow.
I only edited the readme.md file, so it would only affect people who look at the github, just a thing that I noticed.